### PR TITLE
Highlight button got oval shape

### DIFF
--- a/css/_toolbars.scss
+++ b/css/_toolbars.scss
@@ -72,8 +72,9 @@
         }
 
         .button-group-center {
+            display:  flex;
             justify-content: center;
-
+            align-items: center;
             .toolbox-button {
 
                 .toolbox-icon {

--- a/react/features/toolbox/components/web/ToolbarButtonWithoutIcon.js
+++ b/react/features/toolbox/components/web/ToolbarButtonWithoutIcon.js
@@ -8,8 +8,12 @@ import styled from 'styled-components';
  * Styled component for text of button
  */
 const TextContainer = styled.div`
-    font-size : 8px !important;
-    background : transparent !important;
+    font-size : 11px !important;
+    background : white !important;
+    color : black;
+    font-weight: 600;
+    width: 62px !important;
+    height: 45px !important;
 `
 
 /**


### PR DESCRIPTION
Some style of class .button-group-center changed because of non middle vertical alignment